### PR TITLE
Temporary files instead of file descriptors, date prefix for filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.nova/Configuration.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ bashblog
 
 A single Bash script to create blogs.
 
+I have structured the HTML source code semantically.
+
+The `create_css()` function does not yet contain any information for the semantic HTML.
+
 This Version is modified to use temporary files instead of file descriptors for SSH environments, which are actually chroot environments that do not grant direct system access and therefore no access to the file descriptor `/dev/fd/63`.
 
 Created by [cfenollosa](https://github.com/cfenollosa/bashblog) as a very, very simple way to post entries to a blog by using a public folder on a server, without any special requirements and dependencies.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Features
   *Tip: advanced users could mount a remote public folder via `ftpfs` and run this script locally*
 - Allows drafts, includes a simple but clean stylesheet, generates the RSS file automatically.
 - Support for tags/categories
-- Support for Markdown, Disqus comments, Twitter, Feedburner, Google Analytics.
+- Support for Markdown, Disqus comments, ~Twitter, Feedburner, Google Analytics~.
 - The project is still maintained as of 2016. Bugs are fixed, and new features are considered (see "Contributing")
 - Everything stored in a single ~1k lines bash script, how cool is that?! ;) 
 
@@ -104,14 +104,13 @@ Detailed features
 - Save posts as drafts and resume editing later
 - HTML page for each post, using its title as the URL
 - Configurable number of posts on the front page
-- Automatic generation of an RSS file, feedburner support
+- Automatic generation of an RSS file ~, feedburner support~
 - Additional page containing an index of all posts
 - Automatically generates pages for each tag
 - Rebuild all files while keeping the original data
 - Comments delegated to Twitter, with additional Disqus support
-- An option for cookieless Twitter sharing, to comply with the 
-[EU cookie law](https://github.com/cfenollosa/eu-cookie-law)
-- Google Analytics code support
+- ~An option for cookieless Twitter sharing, to comply with the [EU cookie law](https://github.com/cfenollosa/eu-cookie-law)~
+- ~Google Analytics code support~
 - Contains its own CSS so that everything is reasonably styled by default
 - Headers, footers, and in general everything that a well-structured html file needs
 - Support to add extra content on top of every page (e.g. banners, images, etc)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bashblog
 ========
 
-A single Bash script to create blogs. 
+A single Bash script to create blogs. This Version is modified to use temporary files instead of file descriptors for SSH environments, which are actually chroot environments that do not grant direct system access and therefore no access to the file descriptor `/dev/fd/63`.
 
 Created by [cfenollosa](https://github.com/cfenollosa/bashblog) as a very, very simple way to post entries to a blog by using a public folder on a server, without any special requirements and dependencies.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 bashblog
 ========
 
-A single Bash script to create blogs. This Version is modified to use temporary files instead of file descriptors for SSH environments, which are actually chroot environments that do not grant direct system access and therefore no access to the file descriptor `/dev/fd/63`.
+A single Bash script to create blogs.
+
+This Version is modified to use temporary files instead of file descriptors for SSH environments, which are actually chroot environments that do not grant direct system access and therefore no access to the file descriptor `/dev/fd/63`.
 
 Created by [cfenollosa](https://github.com/cfenollosa/bashblog) as a very, very simple way to post entries to a blog by using a public folder on a server, without any special requirements and dependencies.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A single Bash script to create blogs.
 
 I have structured the HTML source code semantically.
 
-The `create_css()` function does not yet contain any information for the semantic HTML.
-
 This Version is modified to use temporary files instead of file descriptors for SSH environments, which are actually chroot environments that do not grant direct system access and therefore no access to the file descriptor `/dev/fd/63`.
 
 Created by [cfenollosa](https://github.com/cfenollosa/bashblog) as a very, very simple way to post entries to a blog by using a public folder on a server, without any special requirements and dependencies.

--- a/bb.sh
+++ b/bb.sh
@@ -966,6 +966,9 @@ make_json() {
         echo '"home_page_url": "'$global_url/$index_file'",'
         echo '"feed_url": "'$global_url/$feed_json'",'
         echo '"description": "'$global_description'",'
+        echo '"author": {'
+        echo '"name": "'$global_author'"'
+        echo '},'
         echo '"language": "de",'
         echo '"items": ['
     

--- a/bb.sh
+++ b/bb.sh
@@ -36,13 +36,6 @@ global_variables() {
     # CC by-nc-nd is a good starting point, you can change this to "&copy;" for Copyright
     global_license="CC by-nc-nd"
 
-    # If you have a Google Analytics ID (UA-XXXXX) and wish to use the standard
-    # embedding code, put it on global_analytics
-    # If you have custom analytics code (i.e. non-google) or want to use the Universal
-    # code, leave global_analytics empty and specify a global_analytics_file
-    global_analytics=""
-    global_analytics_file=""
-
     # Change this to your disqus username to use disqus for comments
     global_disqus_username=""
 
@@ -186,30 +179,6 @@ markdown() {
     while [[ -f $out ]]; do out=${out%.html}.$RANDOM.html; done
     $markdown_bin "$1" > "$out"
     echo "$out"
-}
-
-
-# Prints the required google analytics code
-google_analytics() {
-    [[ -z $global_analytics && -z $global_analytics_file ]]  && return
-
-    if [[ -z $global_analytics_file ]]; then
-        echo "<script type=\"text/javascript\">
-
-        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', '${global_analytics}']);
-        _gaq.push(['_trackPageview']);
-
-        (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-        })();
-
-        </script>"
-    else
-        cat "$global_analytics_file"
-    fi
 }
 
 # Prints the required code for disqus comments
@@ -383,7 +352,6 @@ create_html_page() {
     {
         cat ".header.html"
         echo "<title>$title</title>"
-        google_analytics
         echo "</head><body>"
         # stuff to add before the actual body content
         [[ -n $body_begin_file ]] && cat "$body_begin_file"

--- a/bb.sh
+++ b/bb.sh
@@ -109,6 +109,10 @@ global_variables() {
     css_include=()
     # HTML files to exclude from index, f.ex. post_exclude=('imprint.html 'aboutme.html')
     html_exclude=()
+    # add specific favicon
+    # a favicon is used as logo/icon the blog in the browser
+    # use the realtiv path to it and it must be an .ico file
+    favicon=""
 
     # Localization and i18n
     # "Comments?" (used in twitter link after every post)
@@ -1021,6 +1025,7 @@ create_includes() {
         echo '<html><head>'
         echo '<meta charset="UTF-8">'
         echo '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+        echo '<link rel="shortcut icon" href="$favicon">'
         printf '<link rel="stylesheet" href="%s" type="text/css">\n' "${css_include[@]}"
         if [[ -z $global_feedburner ]]; then
             echo "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"$template_subscribe_browser_button\" href=\"$blog_feed\">"

--- a/bb.sh
+++ b/bb.sh
@@ -28,8 +28,8 @@ global_variables() {
 
     # Your name
     global_author="John Smith"
-    # You can use twitter or facebook or anything for global_author_url
-    global_author_url="http://twitter.com/example" 
+    # You can use bluesky or facebook or anything for global_author_url
+    global_author_url="http://bsky.app/profile/example" 
     # Your email
     global_email="john@smith.com"
 
@@ -46,16 +46,6 @@ global_variables() {
     # Leave this empty (i.e. "") if you don't want to use feedburner, 
     # or change it to your own URL
     global_feedburner=""
-
-    # Change this to your username if you want to use twitter for comments
-    global_twitter_username=""
-    # Default image for the Twitter cards. Use an absolute URL
-    global_twitter_card_image=""
-    # Set this to false for a Twitter button with share count. The cookieless version
-    # is just a link.
-    global_twitter_cookieless="true"
-    # Default search page, where tweets more than a week old are hidden
-    global_twitter_search="twitter"
 
     # Change this to your disqus username to use disqus for comments
     global_disqus_username=""
@@ -115,8 +105,6 @@ global_variables() {
     favicon=""
 
     # Localization and i18n
-    # "Comments?" (used in twitter link after every post)
-    template_comments="Comments?"
     # "Read more..." (link under cut article on index page)
     template_read_more="Read more..."
     # "View more posts" (used on bottom of index page as link to archive)
@@ -139,9 +127,6 @@ global_variables() {
     template_subscribe="Subscribe"
     # "Subscribe to this page..." (used as text for browser feed button that is embedded to html)
     template_subscribe_browser_button="Subscribe to this page..."
-    # "Tweet" (used as twitter text button for posting to twitter)
-    template_twitter_button="Tweet"
-    template_twitter_comment="&lt;Type your comment here but please leave the URL so that other people can follow the comments&gt;"
     
     # The locale to use for the dates displayed on screen
     date_format="%B %d, %Y"
@@ -344,61 +329,7 @@ edit() {
     fi
 }
 
-# Create a Twitter summary (twitter "card") for the post
-#
-# $1 the post file
-# $2 the title
-twitter_card() {
-    [[ -z $global_twitter_username ]] && return
-    
 
-    echo "<meta name='twitter:card' content='summary'>"
-    echo "<meta name='twitter:site' content='@$global_twitter_username'>"
-    echo "<meta name='twitter:title' content='$2'>" # Twitter truncates at 70 char
-    description=$(grep -v "^<p>$template_tags_line_header" "$1" | sed -e 's/<[^>]*>//g' | tr '\n' ' ' | sed "s/\"/'/g" | head -c 250) 
-    echo "<meta name='twitter:description' content=\"$description\">"
-
-    # For the image we try to locate the first image in the article
-    image=$(sed -n '2,$ d; s/.*<img.*src="\([^"]*\)".*/\1/p' "$1") 
-
-    # If none, then we try a global setting image
-    [[ -z $image ]] && [[ -n $global_twitter_card_image ]] && image=$global_twitter_card_image
-
-    # If none, return
-    [[ -z $image ]] && return
-
-    # Final housekeeping
-    [[ $image =~ ^https?:// ]] || image=$global_url/$image # Check that URL is absolute
-    echo "<meta name='twitter:image' content='$image'>"
-}
-
-# Adds the code needed by the twitter button
-#
-# $1 the post URL
-twitter() {
-    [[ -z $global_twitter_username ]] && return
-
-    if [[ -z $global_disqus_username ]]; then
-        if [[ $global_twitter_cookieless == true ]]; then 
-            id=$RANDOM
-
-            search_engine="https://twitter.com/search?q="
-
-            echo "<p id='twitter'><a href='http://twitter.com/intent/tweet?url=$1&text=$template_twitter_comment&via=$global_twitter_username'>$template_comments $template_twitter_button</a> "
-            echo "<a href='$search_engine""$1'><span id='count-$id'></span></a>&nbsp;</p>"
-            return;
-        else 
-            echo "<p id='twitter'>$template_comments&nbsp;"; 
-        fi
-    else
-        echo "<p id='twitter'><a href=\"$1#disqus_thread\">$template_comments</a> &nbsp;"
-    fi  
-
-    echo "<a href=\"https://twitter.com/share\" class=\"twitter-share-button\" data-text=\"$template_twitter_comment\" data-url=\"$1\""
-    echo " data-via=\"$global_twitter_username\""
-    echo ">$template_twitter_button</a>	<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=\"//platform.twitter.com/widgets.js\";fjs.parentNode.insertBefore(js,fjs);}}(document,\"script\",\"twitter-wjs\");</script>"
-    echo "</p>"
-}
 
 # Check if the file is a 'boilerplate' (i.e. not a post)
 # The return values are designed to be used like this inside a loop:
@@ -452,7 +383,6 @@ create_html_page() {
         cat ".header.html"
         echo "<title>$title</title>"
         google_analytics
-        twitter_card "$content" "$title"
         echo "</head><body>"
         # stuff to add before the actual body content
         [[ -n $body_begin_file ]] && cat "$body_begin_file"
@@ -494,9 +424,6 @@ create_html_page() {
         cat "$content" # Actual content
         if [[ $index == no ]]; then
             echo -e '\n<!-- text end -->'
-
-            twitter "$global_url/$file_url"
-
             echo '<!-- entry end -->' # absolute end of the post
         fi
 
@@ -1068,8 +995,7 @@ create_css() {
         #description{font-size:large;margin-bottom:12px;}
         h3{margin-top:42px;margin-bottom:8px;}
         h4{margin-left:24px;margin-right:24px;}
-        img{max-width:100%;}
-        #twitter{line-height:20px;vertical-align:top;text-align:right;font-style:italic;color:#333;margin-top:24px;font-size:14px;}' > blog.css
+        img{max-width:100%;}' > blog.css
     fi
 
     # If there is a style.css from the parent page (i.e. some landing page)

--- a/bb.sh
+++ b/bb.sh
@@ -1226,16 +1226,17 @@ do_main() {
     # Test for existing html files
     if ls ./*.html &> /dev/null; then
         # We're going to back up just in case
-        tar -c -z -f ".backup.tar.gz" -- *.html &&
-            chmod 600 ".backup.tar.gz"
+        mkdir -p "backups/"
+        tar -c -z -f "backups/.backup.tar.gz" -- *.html &&
+            chmod 600 "backups/.backup.tar.gz"
     elif [[ $1 == rebuild ]]; then
         echo "Can't find any html files, nothing to rebuild"
         exit
     fi
 
     # Keep first backup of this day containing yesterday's version of the blog
-    [[ ! -f .yesterday.tar.gz || $(date -r .yesterday.tar.gz +'%d') != "$(date +'%d')" ]] &&
-        cp .backup.tar.gz .yesterday.tar.gz &> /dev/null
+    [[ ! -f backups/.yesterday.tar.gz || $(date -r backups/.yesterday.tar.gz +'%d') != "$(date +'%d')" ]] &&
+        cp backups/.backup.tar.gz backups/.yesterday.tar.gz &> /dev/null
 
     [[ $1 == reset ]] &&
         reset && exit

--- a/bb.sh
+++ b/bb.sh
@@ -1143,7 +1143,7 @@ reset() {
     echo "Are you sure you want to delete all blog entries? Please write \"Yes, I am!\" "
     read -r line
     if [[ $line == "Yes, I am!" ]]; then
-        rm .*.html ./*.html ./*.css ./*.rss &> /dev/null
+        rm .*.html ./*.html ./*.css ./*.rss ./*.json &> /dev/null
         echo
         echo "Deleted all posts, stylesheets and feeds."
         echo "Kept your old '.backup.tar.gz' just in case, please delete it manually if needed."

--- a/bb.sh
+++ b/bb.sh
@@ -92,7 +92,7 @@ global_variables() {
     # extra content to ONLY on the index page AFTER `body_begin_file` contents
     # and before the actual content
     body_begin_file_index=""
-    # CSS files to include on every page, f.ex. css_include=('main.css' 'blog.css')
+    # CSS files to include on every page, f.ex. css_include=('main.css')
     # leave empty to use generated
     css_include=()
     # HTML files to exclude from index, f.ex. post_exclude=('imprint.html 'aboutme.html')
@@ -643,7 +643,7 @@ all_posts() {
         echo "</ul>"
         echo "</article>"
         echo "<section class=\"subnav\">"
-        echo "<div id=\"all_posts\"><a href=\"./$index_file\">$template_archive_index_page</a></div>"
+        echo "<div class=\"subnav\"><a href=\"./$index_file\">$template_archive_index_page</a></div>"
         echo "</section>"
     } 3>&1 >"$contentfile"
 
@@ -682,7 +682,7 @@ all_tags() {
         echo "</ul>"
         echo "</article>"
         echo "<section class=\"subnav\">"
-        echo "<div id=\"all_posts\"><a href=\"./$index_file\">$template_archive_index_page</a></div>"
+        echo "<div class=\"subnav\"><a href=\"./$index_file\">$template_archive_index_page</a></div>"
         echo "</section>"
     } 3>&1 > "$contentfile"
 
@@ -723,7 +723,7 @@ rebuild_index() {
         rss=$feed_rss
         json=$feed_json
         echo "<section>"
-        echo "<div id=\"all_posts\"><a href=\"$archive_index\">$template_archive</a> &ndash; <a href=\"$tags_index\">$template_tags_title</a> &ndash; <a href=\"$rss\">$template_subscribe_rss</a> &ndash; <a href=\"$json\">$template_subscribe_json</a></div>"
+        echo "<div class=\"subnav\"><a href=\"$archive_index\">$template_archive</a> &ndash; <a href=\"$tags_index\">$template_tags_title</a> &ndash; <a href=\"$rss\">$template_subscribe_rss</a> &ndash; <a href=\"$json\">$template_subscribe_json</a></div>"
         echo "</section>"
     } 3>&1 >"$contentfile"
 
@@ -1043,45 +1043,10 @@ delete_includes() {
 # Create the css file from scratch
 create_css() {
     # To avoid overwriting manual changes. However it is recommended that
-    # this function is modified if the user changes the blog.css file
-    (( ${#css_include[@]} > 0 )) && return || css_include=('main.css' 'blog.css')
-    if [[ ! -f blog.css ]]; then 
-        # blog.css directives will be loaded after main.css and thus will prevail
-        echo '#title{font-size: x-large;}
-        li{margin-bottom:8px;}
-        ul,ol{margin-left:24px;margin-right:24px;}
-        #all_posts{margin-top:24px;text-align:center;}
-        .subtitle{font-size:small;margin:12px 0px;}
-        .content p{margin-left:24px;margin-right:24px;}
-        h1{margin-bottom:12px !important;}
-        #description{font-size:large;margin-bottom:12px;}
-        h2{margin-top:42px;margin-bottom:8px;}
-        h3{margin-left:24px;margin-right:24px;}
-        img{max-width:100%;}' > blog.css
-    fi
-
-    # If there is a style.css from the parent page (i.e. some landing page)
-    # then use it. This directive is here for compatibility with my own
-    # home page. Feel free to edit it out, though it doesn't hurt
-    if [[ -f ../style.css ]] && [[ ! -f main.css ]]; then
-        ln -s "../style.css" "main.css" 
-    elif [[ ! -f main.css ]]; then
-        echo 'body{font-family:Georgia,"Times New Roman",Times,serif;margin:0;padding:0;background-color:#F3F3F3;}
-        #divbodyholder{padding:5px;background-color:#DDD;width:100%;max-width:874px;margin:24px auto;}
-        #divbody{border:solid 1px #ccc;background-color:#fff;padding:0px 48px 24px 48px;top:0;}
-        .headerholder{background-color:#f9f9f9;border-top:solid 1px #ccc;border-left:solid 1px #ccc;border-right:solid 1px #ccc;}
-        .header{width:100%;max-width:800px;margin:0px auto;padding-top:24px;padding-bottom:8px;}
-        .content{margin-bottom:5%;}
-        .nomargin{margin:0;}
-        .description{margin-top:10px;border-top:solid 1px #666;padding:10px 0;}
-        h2{font-size:20pt;width:100%;font-weight:bold;margin-top:32px;margin-bottom:0;}
-        .clear{clear:both;}
-        #footer{padding-top:10px;border-top:solid 1px #666;color:#333333;text-align:center;font-size:small;font-family:"Courier New","Courier",monospace;}
-        a{text-decoration:none;color:#003366 !important;}
-        a:visited{text-decoration:none;color:#336699 !important;}
-        blockquote{background-color:#f9f9f9;border-left:solid 4px #e9e9e9;margin-left:12px;padding:12px 12px 12px 24px;}
-        blockquote img{margin:12px 0px;}
-        blockquote iframe{margin:12px 0px;}' > main.css
+    # this function is modified if the user changes the main.css file
+    (( ${#css_include[@]} > 0 )) && return || css_include=('main.css')
+    if [[ ! -f main.css ]]; then
+        echo '*,*:before,*:after{box-sizing:inherit;margin:0;padding:0}::before,::after{text-decoration:inherit;vertical-align:inherit}:where(:root){box-sizing:border-box;-moz-text-size-adjust:none;-webkit-text-size-adjust:none;text-size-adjust:none;background-color:#16161d;font-family:system-ui,ui-sans-serif,sans-serif;position:relative;color:#b5b5b5;min-height:100%}body{position:relative;min-height:100vh;font-size:100%;line-height:1.5;width:100%;margin:0}body>header,body>main,body>footer{background-color:#16161d;max-width:874px;margin-inline:auto;padding-inline:1rem}main{display:block}footer .credit{padding-block:1rem;text-align:center;font-size:small}article{margin-block:2rem}article:first-of-type{margin-block-start:0}article:last-of-type{scroll-margin-block-end:0}article p:not(:last-of-type){margin-block-end:.5rem}article p:last-of-type{font-size:small}article .subtitle{font-size:small;font-style:italic;margin-block-end:.5rem}a,a:visited,a:hover{text-decoration:none;color:#e1e1e1}input,textarea,button{font-size:inherit;font-family:inherit}ul,ol{margin-left:24px;margin-right:24px}h1,h2,h3,h4,h5,h6{color:#e1e1e1}h1{font-size:1.75rem;line-height:1.15;margin-top:2.625rem}h2{font-size:1.5rem;line-height:1.175;margin-top:2.25rem}h3{font-size:1.25rem;line-height:1.2;margin-top:1.874rem}h4{font-size:1.125rem;line-height:1.225;margin-top:1.6875rem}h6{font-size:1rem;line-height:1.25;margin-top:1.5rem}img{max-width:100%}blockquote{border-left:solid 4px #e9e9e9;margin-left:12px;padding:12px 12px 12px 24px}blockquote img{margin:12px 0px}blockquote iframe{margin:12px 0px}.description{font-size:large;margin-bottom:12px}.subnav{margin-block:3rem;text-align:center;font-size:small}.clear{clear:both}' > main.css
     fi
 }
 

--- a/bb.sh
+++ b/bb.sh
@@ -977,7 +977,7 @@ make_json() {
             ((n >= number_of_feed_articles)) && break # max 10 items
             pubdate=$(LC_ALL=C date -r "$i" +"$date_format_json")
             post_title=$(get_post_title "$i")
-            post_content=$(get_html_file_content 'text' 'entry' $cut_do <"$i")
+            post_content=$(get_html_file_content 'text' 'entry' $cut_do <"$i" | tr "\"" "'") # write the HTML content into a variable ands replace double quotes with single quotes for valid json
             echo -n "." 1>&3
             echo '{'
             echo '"id": "'$global_url/${i#./}'",'

--- a/bb.sh
+++ b/bb.sh
@@ -401,12 +401,12 @@ create_html_page() {
         if [[ $index == no ]]; then
             echo '<!-- entry begin -->' # marks the beginning of the whole post
             echo '<article>'
-            echo "<h3><a class=\"ablack\" href=\"$file_url\">"
+            echo "<h2><a href=\"$file_url\">"
             # remove possible <p>'s on the title because of markdown conversion
             title=${title//<p>/}
             title=${title//<\/p>/}
             echo "$title"
-            echo '</a></h3>'
+            echo '</a></h2>'
             if [[ -z $timestamp ]]; then
                 echo "<!-- $date_inpost: #$(LC_ALL=$date_locale date +"$date_format_timestamp")# -->"
             else
@@ -613,7 +613,7 @@ all_posts() {
 
     {
         echo "<article>"
-        echo "<h3>$template_archive_title</h3>"
+        echo "<h2>$template_archive_title</h2>"
         prev_month=""
         tmpfile=$(mktemp)
         list_html_by_timestamp > "$tmpfile"
@@ -627,7 +627,7 @@ all_posts() {
             month=$(LC_ALL=$date_locale date -r "$i" +"$date_allposts_header")
             if [[ $month != "$prev_month" ]]; then
                 [[ -n $prev_month ]] && echo "</ul>"  # Don't close ul before first header
-                echo "<h4 class='allposts_header'>$month</h4>"
+                echo "<h3 class='allposts_header'>$month</h3>"
                 echo "<ul>"
                 prev_month=$month
             fi
@@ -663,7 +663,7 @@ all_tags() {
 
     {
         echo "<article>"
-        echo "<h3>$template_tags_title</h3>"
+        echo "<h2>$template_tags_title</h2>"
         echo "<ul>"
         for i in $prefix_tags*.html; do
             [[ -f "$i" ]] || break
@@ -749,7 +749,7 @@ posts_with_tags() {
     (($# < 1)) && return
     set -- "${@/#/$prefix_tags}"
     set -- "${@/%/.html}"
-    sed -n '/^<h3><a class="ablack" href="[^"]*">/{s/.*href="\([^"]*\)">.*/\1/;p;}' "$@" 2> /dev/null
+    sed -n '/^<h2><a href="[^"]*">/{s/.*href="\([^"]*\)">.*/\1/;p;}' "$@" 2> /dev/null
 }
 
 # Rebuilds tag_*.html files
@@ -817,7 +817,7 @@ rebuild_tags() {
 #
 # $1 the html file
 get_post_title() {
-    awk '/<h3><a class="ablack" href=".+">/, /<\/a><\/h3>/{if (!/<h3><a class="ablack" href=".+">/ && !/<\/a><\/h3>/) print}' "$1"
+    awk '/<h2><a href=".+">/, /<\/a><\/h2>/{if (!/<h2><a href=".+">/ && !/<\/a><\/h2>/) print}' "$1"
 }
 
 # Return the post author
@@ -1045,7 +1045,6 @@ create_css() {
     if [[ ! -f blog.css ]]; then 
         # blog.css directives will be loaded after main.css and thus will prevail
         echo '#title{font-size: x-large;}
-        a.ablack{color:black !important;}
         li{margin-bottom:8px;}
         ul,ol{margin-left:24px;margin-right:24px;}
         #all_posts{margin-top:24px;text-align:center;}
@@ -1053,8 +1052,8 @@ create_css() {
         .content p{margin-left:24px;margin-right:24px;}
         h1{margin-bottom:12px !important;}
         #description{font-size:large;margin-bottom:12px;}
-        h3{margin-top:42px;margin-bottom:8px;}
-        h4{margin-left:24px;margin-right:24px;}
+        h2{margin-top:42px;margin-bottom:8px;}
+        h3{margin-left:24px;margin-right:24px;}
         img{max-width:100%;}' > blog.css
     fi
 
@@ -1072,7 +1071,7 @@ create_css() {
         .content{margin-bottom:5%;}
         .nomargin{margin:0;}
         .description{margin-top:10px;border-top:solid 1px #666;padding:10px 0;}
-        h3{font-size:20pt;width:100%;font-weight:bold;margin-top:32px;margin-bottom:0;}
+        h2{font-size:20pt;width:100%;font-weight:bold;margin-top:32px;margin-bottom:0;}
         .clear{clear:both;}
         #footer{padding-top:10px;border-top:solid 1px #666;color:#333333;text-align:center;font-size:small;font-family:"Courier New","Courier",monospace;}
         a{text-decoration:none;color:#003366 !important;}

--- a/bb.sh
+++ b/bb.sh
@@ -154,7 +154,8 @@ global_variables() {
     # Experts only. You may need to tune the locales too
     # Leave empty for no conversion, which is not recommended
     # This default filter respects backwards compatibility
-    convert_filename="iconv -f utf-8 -t ascii//translit | sed 's/^-*//' | tr [:upper:] [:lower:] | tr ' ' '-' | tr -dc '[:alnum:]-'"
+    # Date in Format `yyyy-mm-dd` is prefixed to the file name
+    convert_filename="date +%F | tr -d '\n' && echo -n '-' && iconv -f utf-8 -t ascii//translit | sed 's/^-*//' | tr [:upper:] [:lower:] | tr ' ' '-' | tr -dc '[:alnum:]-'"
 
     # URL where you can view the post while it's being edited
     # same as global_url by default


### PR DESCRIPTION
Hi,

here are a few adjustments to your version of bashblog:

1. because my SSH environment, which is actually a chroot environment that do not grant direct system access and therefore no access to the file descriptor `/dev/fd/63` I had make some changes to the skript to use temporary files instead of.
2. For clarity on the server, I have added the post date to the global variable `convert_filename`, which now precedes the file name.
3. I have added the change with the temporary files to the readme.

I hope the PR is ok for you.